### PR TITLE
Update actions.js

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -18,7 +18,7 @@ module.exports = {
 					id:      'qlId',
 					default:  1,
 					min:      1,
-					max:      1000,
+					max:      32768,
 					required: true,
 					range:    false
 				},


### PR DESCRIPTION
I was working with a hog and when I tried to run a scene that was over 1000, the text turned red. The hog supports up to 32768 scenes, so I figured that I would PR so it does not turn red with a value that will still work with the console.